### PR TITLE
Fix CI requiring original repo (#560)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
           path: dist
       # Deploy Preview
       - name: Deploy Preview
-        if: github.ref != 'refs/heads/master' && github.event.repository.fork == false
+        if: github.ref != 'refs/heads/master' && !github.event.pull_request.head.repo.fork
         run: npm run deploy:preview -- --auth ${{secrets.NETLIFY_AUTH_TOKEN}} --alias $GITHUB_RUN_ID
       # Deploy Production
       - name: Deploy Production
-        if: github.ref == 'refs/heads/master' && github.event.repository.fork == false
+        if: github.ref == 'refs/heads/master' && !github.event.pull_request.head.repo.fork
         run: npm run deploy:prod -- --auth ${{secrets.NETLIFY_AUTH_TOKEN}}


### PR DESCRIPTION
## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

- **fix**: This should fix the CI failing on forks.

## 🌄 Context

I had noticed when fixing the issue of the cap on Numeric fields that the CI consistently failed. Looking from the build logs, I think the issue is that it looks for secrets related to the main repo in a way that seems hardcoded. This _should_ fix that particular issue.

## ✅ Changes

<!-- Use prefixes: **chore**, **docs**, **feat**, **fix**, **refactor**, **style** or **test** -->

-

## 🌄 Context

<!-- Provide more context around why this pull request was created -->

## 🔒Checklist

- I tested my work on the feature environment

## 💅 Examples

<!-- Give examples or screenshots detailing the new behaviors of the application -->
